### PR TITLE
Fix oci-umount to unmount bunch of mount points during container startup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,6 @@ oci_umount_CFLAGS = -Wall -Wextra -std=c99 $(YAJL_CFLAGS)
 oci_umount_LDADD = $(YAJL_LIBS)
 oci_umount_CFLAGS += $(SELINUX_CFLAGS)
 oci_umount_LDADD += $(SELINUX_LIBS)
-oci_umount_CFLAGS += $(LIBMOUNT_CFLAGS)
-oci_umount_LDADD += $(LIBMOUNT_LIBS)
 
 dist_man_MANS = oci-umount.1
 EXTRA_DIST = README.md LICENSE

--- a/oci-umount.conf
+++ b/oci-umount.conf
@@ -1,3 +1,8 @@
- /var/lib/docker/overlay2
- /var/lib/docker/overlay
- /var/lib/docker/devicemapper
+/var/lib/docker/overlay2
+/var/lib/docker/overlay
+/var/lib/docker/devicemapper
+/var/lib/docker/containers
+/var/lib/docker-latest/overlay2
+/var/lib/docker-latest/overlay
+/var/lib/docker-latest/devicemapper
+/var/lib/docker-latest/containers

--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -21,8 +21,6 @@
 
 #include "config.h"
 
-#include <libmount/libmount.h>
-
 #define _cleanup_(x) __attribute__((cleanup(x)))
 
 #define MOUNTCONF "/etc/oci-umount.conf"
@@ -83,23 +81,9 @@ static inline void free_cptr_array(char ***p) {
 	free(ptr);
 }
 
-static inline void mnt_free_iterp(struct libmnt_iter **itr) {
-	if (*itr)
-		mnt_free_iter(*itr);
-	*itr=NULL;
-}
-
-static inline void mnt_free_fsp(struct libmnt_fs **itr) {
-	if (*itr)
-		mnt_free_fs(*itr);
-	*itr=NULL;
-}
-
 #define _cleanup_free_ _cleanup_(freep)
 #define _cleanup_close_ _cleanup_(closep)
 #define _cleanup_fclose_ _cleanup_(fclosep)
-#define _cleanup_mnt_iter_ _cleanup_(mnt_free_iterp)
-#define _cleanup_mnt_fs_ _cleanup_(mnt_free_fsp)
 #define _cleanup_mnt_info_ _cleanup_(free_mnt_info)
 #define _cleanup_cptr_array_ _cleanup_(free_cptr_array)
 

--- a/src/oci-umount.c
+++ b/src/oci-umount.c
@@ -118,16 +118,6 @@ DEFINE_CLEANUP_FUNC(yajl_val, yajl_tree_free)
 #define BUFLEN 1024
 #define CHUNKSIZE 4096
 
-static bool contains_mount(const struct config_mount_info *config_mounts, unsigned len, const char *mount) {
-	for (unsigned i = 0; i < len; i++) {
-		if (!strcmp(mount, config_mounts[i].destination)) {
-			pr_pdebug("%s already present as a mount point in container configuration, skipping\n", mount);
-			return true;
-		}
-	}
-	return false;
-}
-
 static void *grow_mountinfo_table(void *curr_table, size_t curr_sz, size_t new_sz) {
 	void *table;
 


### PR DESCRIPTION
Fix oci-umount to unmount bunch of mount points during startup. These are supposed to be docker private mount points which container should not be seeing/using.